### PR TITLE
Adding UPI radio for WMP platform (wishful_upis/wmp/radio.py)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+#python editor
+.idea

--- a/wishful_upis/__init__.py
+++ b/wishful_upis/__init__.py
@@ -7,3 +7,4 @@ from . import context
 from . import lte
 from . import wifi
 from . import zigbee
+from . import wmp

--- a/wishful_upis/radio.py
+++ b/wishful_upis/radio.py
@@ -24,6 +24,7 @@ PARAMETERS = [
 ]
 
 
+
 # Generic API to control the lower layers, i.e. key-value configuration.
 def set_parameters(param_key_values_dict):
     """The UPI_R interface is able to configure the radio and MAC behavior by changing parameters.
@@ -246,8 +247,9 @@ def stop_waveform(iface, **kwargs):
     '''
     pass
 
-
-def set_tx_power(power_dBm):
+#to rename when will be updated the wifi module
+#def set_tx_power(power_dBm):
+def set_power(power_dBm):
     '''func desc
 
     Args:
@@ -255,12 +257,12 @@ def set_tx_power(power_dBm):
     '''
     pass
 
-
-def get_tx_power():
+#to rename when will be updated the wifi module
+#def get_tx_power():
+def get_power():
     '''func desc
     '''
     pass
-
 
 def get_noise():
     '''Returns the noise floor measured by the wireless driver.
@@ -280,16 +282,57 @@ def stop_csi_measurements():
     pass
 
 
-def get_radio_info():
-    '''func desc
-    '''
-    pass
-
-
 def get_radio_platforms():
-    '''func desc
-    '''
-    pass
+    """ Gets available NIC on board and type of supported platforms. The information elements used by the UPI_R
+    interface, to manage parameters, measurements and radio program, are organized into data structures,
+    which provide information on the platform type and radio capabilities.
+    When executed, this function return information about available interfaces on node, the name or the identifier
+    of the interface and the supported platform type.
+
+    :return current_NIC_list: a list of pair value, the first value is the interface identifier and the second is the supported platforms.
+
+    example:
+        >> current_NIC_list = RadioPlatform_t()
+        >> current_NIC_list_string = UPI_RN.getRadioPlatforms()
+        >> current_NIC_list.platform_info =  current_NIC_list_string[0]
+        >> current_NIC_list.platform =  current_NIC_list_string[1]
+    """
+    return
+
+
+def get_radio_info(radio_id):
+    """Gets the radio capabilities of a given network card RadioPlatform_t in terms of supported measurement and supported
+    parameter and list of supported radio program. The information elements used by the UPI_R interface, to manage
+    parameters, measurements and radio program, are organized into data structures, which provide information
+    on the platform type and radio capabilities. When executed, this function return information about available
+    radio capabilities (measurements and parameters) of each interface (RadioPlatform_t) on the available radio programs
+    (radio_prg_t) available for transmissions over the radio interface.
+
+    :param radio_id: network interfaces to use
+    :return result: return a list in term of a dictionary data type (list of key: value). in which are present the key showed below:
+            'radio_info' --> a list of pair value, the first value is the interface identifier and the second is the supported platforms.
+            'monitor_list' --> a list of supported measurements between the attribute of the class UPI_R
+            'param_list' --> a list of supported Parameters between the attribute of the class UPI_R
+            'exec_engine_list_name' --> a list of supported execution environment name
+            'exec_engine_list_pointer' --> a list of supported execution environment path
+            'radio_prg_list_name'--> a list of supported radio program name
+            'radio_prg_list_pointer' --> a list of supported radio program path
+
+    example:
+            >> interface = 'wlan0'\n
+            >> current_platform_info = radio_info_t()\n
+            >> param_key = {'platform' : 'wmp'}\n
+            >> current_platform_info_str = UPI_RN.getRadioInfo(interface, param_key)\n
+            >> current_platform_info.platform_info.platform_id = current_platform_info_str['radio_info'][0]\n
+            >> current_platform_info.platform_info.platform = current_platform_info_str['radio_info'][1]\n
+            >> current_platform_info.monitor_list = current_platform_info_str['monitor_list']\n
+            >> current_platform_info.param_list = current_platform_info_str['param_list']\n
+            >> current_platform_info.execution_engine_list_name = current_platform_info_str['exec_engine_list_name']\n
+            >> current_platform_info.execution_engine_list_pointer = current_platform_info_str['exec_engine_list_pointer']\n
+            >> current_platform_info.radio_program_list_name = current_platform_info_str['radio_prg_list_name']\n
+            >> current_platform_info.radio_program_list_path = current_platform_info_str['radio_prg_list_pointer']\n
+    """
+    return
 
 
 def set_rxchannel(freq_Hz, bandwidth):

--- a/wishful_upis/wmp/__init__.py
+++ b/wishful_upis/wmp/__init__.py
@@ -1,0 +1,1 @@
+from . import radio

--- a/wishful_upis/wmp/radio.py
+++ b/wishful_upis/wmp/radio.py
@@ -1,0 +1,53 @@
+"""The WiSHFUL radio control interface, UPI_R.
+Used for configuration/monitoring of the lower
+layers of the network protocol stack (lower MAC and PHY).
+
+Note, the functions can be supported by WMP platform.
+
+"""
+__author__ = "Domenico Garlisi"
+__copyright__ = "Copyright (c) 2016, CNIT"
+__version__ = "0.1.0"
+__email__ = "{domenico.garlisi@cnit.it}"
+
+"""
+UPI_M
+"""
+def install_execution_engine(myargs):
+    """The architectures of the nodes present in the testbed define an execution environment or execution engine
+    able to run radio programs defined in a high-level programming language. This management function install an
+    execution environment on a node. If the execution engine is implemented on the microcode wireless card, the
+    function the copy and able the correct microcode.
+
+    :param myargs:list of parameters, in term of a dictionary data type (list of key: value) in which: the key is 'execution_engine' and the value is the path of the execution engine file(s).
+    :return result: return 0 if the parameter setting call was successfully performed, 1 partial success, 2 error.
+
+    example:
+        >> args = {'execution_engine' : ['runtime/connectors/wmp_linux/execution_engine/wmp'] } \n
+        >> result = UPI_M.installExecutionEngine(args) \n
+        >> print result \n
+        0 \n
+    """
+    return
+
+def init_test(myargs):
+    """This function is a management function used to setup the nodes before the experiment, the function can
+    performs different action.They are i) restart the driver module, ii) creates infrastructure BSS, the node
+    is used such Access Point, iii) associate node to infrastructure BSS. The different action are addressing the
+    key 'operation' in the dictionary data type of arguments.
+
+    :param myargs: list of parameters, in term of a dictionary data type (list of key: value) in which: The key "interface" specify the network interface to use. The key 'operaiton' is used to specify the action, the supported value for the key 'operation' are 'module', used to restart the module, 'create-network', used to create the IBSS, and 'association' used to associate the node to the IBSS. The key 'ssid' is used to define the essid of the IBSS. The key 'ip_address' is used to define the ip address of the wireless interface.
+    :return result: return 0 if the parameter setting call was successfully performed, 1 partial success, 2 error.
+
+    example :
+        >> args ={'interface' : 'wlan0', 'operation' : ['create-network'], 'ssid' : ['MyNetwork'], 'ip_address' : ['192.168.1.1'] } ] \n
+        >> result = UPI_M.initTest(args) \n
+        >> print result \n
+        0 \n
+    """
+    return
+
+def get_iface_ip_addr(iface):
+    '''Returns the IP address of a given interface.
+    '''
+    return

--- a/wishful_upis/zigbee/__init__.py
+++ b/wishful_upis/zigbee/__init__.py
@@ -1,0 +1,3 @@
+from . import radio
+from . import net
+from . import net_func

--- a/wishful_upis/zigbee/net.py
+++ b/wishful_upis/zigbee/net.py
@@ -1,0 +1,12 @@
+__author__ = "Piotr Gawlowicz, Zubow"
+__copyright__ = "Copyright (c) 2015, Technische Universitat Berlin"
+__version__ = "0.1.0"
+__email__ = "{gawlowicz, zubow}@tkn.tu-berlin.de"
+
+'''IEEE 802.15.4 protocol family
+
+The protocol-specific definition of the WiSHFUL network control interface,
+UPI_N, for configuration/monitoring of the higher layers of the network
+protocol stack (upper MAC and higher).
+
+'''

--- a/wishful_upis/zigbee/net_func.py
+++ b/wishful_upis/zigbee/net_func.py
@@ -1,0 +1,11 @@
+__author__ = "Piotr Gawlowicz, Anatolij Zubow"
+__copyright__ = "Copyright (c) 2015, Technische Universitat Berlin"
+__version__ = "0.1.0"
+__email__ = "{gawlowicz, zubow}@tkn.tu-berlin.de"
+
+'''IEEE 802.15.4 protocol family
+
+The protocol-specific definition of WiSHFUL global control interface, UPI_G,
+for performing network-wide operations which go beyond just remote UPI_R/N calls
+
+'''

--- a/wishful_upis/zigbee/radio.py
+++ b/wishful_upis/zigbee/radio.py
@@ -1,0 +1,20 @@
+__author__ = "Piotr Gawlowicz, Zubow"
+__copyright__ = "Copyright (c) 2015, Technische Universitat Berlin"
+__version__ = "0.1.0"
+__email__ = "{gawlowicz, zubow}@tkn.tu-berlin.de"
+
+'''IEEE 802.15.4 protocol family
+
+The protocol-specific definition of the WiSHFUL radio control interface, UPI_R,
+for configuration/monitoring of the lower layers of the network protocol stack
+(lower MAC and PHY).
+
+'''
+
+def disable_carrier_sensing():
+    '''Disables carrier sensing
+
+    i.e. no listen-before-talk.
+    '''
+    pass
+


### PR DESCRIPTION
Adding documentation for UPI functions get_radio_platforms() and get_radio_info() (wishful_upis/radio.py)
At the moment, changing name of UPI functions to set and get power (we wait to change them in wishful wifi agent module)
